### PR TITLE
Updated deprecated grunt-bower-hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-htmlmin": "0.1.1rc7",
     "grunt-contrib-imagemin": "0.1.1rc8",
     "grunt-contrib-livereload": "0.1.0rc8",
-    "grunt-bower-hooks": "~0.1.2",
+    "grunt-bower-requirejs": "0.4.1",
     "grunt-usemin": "~0.1.4",
     "grunt-regarde": "~0.1.1",
     "grunt-open": "~0.1.0",


### PR DESCRIPTION
``````
npm http GET https://registry.npmjs.org/grunt-bower-hooks
npm http 304 https://registry.npmjs.org/grunt-bower-hooks
npm WARN deprecated grunt-bower-hooks@0.1.2: Renamed to grunt-bower-requirejs```
``````
